### PR TITLE
Add docs for getting remaining slice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,20 @@ use atoi::atoi;
 assert_eq!(Some(42), atoi::<u32>(b"42"));
 ```
 
+Note that if you want to know how much of the input has been used, you can use the
+`FromRadix10` trait, for example:
+
+```rust
+use atoi::FromRadix10;
+
+/// Return the parsed integer and remaining slice if successful.
+fn atoi_with_rest<I: FromRadix10>(text: &[u8]) -> Option<(&[u8], I)> {
+    match I::from_radix_10(text) {
+        (_, 0) => None,
+        (n, used) => Some((&[used..], n)),
+    }
+}
+```
+
 This [crate](https://www.crates.io/crates/atoi) as more to offer! Check out the full documentation
 at [docs.rs](https://docs.rs/atoi).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,21 @@
 //! Using `str::from_utf8` and `str::parse`
 //! is likely to be more idiomatic. Use this crate if you want to avoid decoding bytes into utf8
 //! (e.g. for performance reasons).
+//!
+//! Note that if you want to know how much of the input has been used, you can use the
+//! `FromRadix10` trait, for example:
+//!
+//! ```rust
+//! use atoi::FromRadix10;
+//!
+//! /// Return the parsed integer and remaining slice if successful.
+//! fn atoi_with_rest<I: FromRadix10>(text: &[u8]) -> Option<(&[u8], I)> {
+//!     match I::from_radix_10(text) {
+//!         (_, 0) => None,
+//!         (n, used) => Some((&[used..], n)),
+//!     }
+//! }
+//! ```
 
 extern crate num_traits;
 use num_traits::{One, Signed, Zero};


### PR DESCRIPTION
I originally wrote my own version of this crate because I mistakenly thought you couldn't get the number of bytes used (you can't using the `atoi` function, you have to use the trait). I've added some docs so others won't make the same mistake.