### PR TITLE
No-std as optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,12 @@ categories = ["parsing"]
 # crates.io will render this file and place the result on the crate's page.
 readme = "README.md"
 
+[features]
+default = ["std"]
+std = ["num-traits/std"]
+
 [dependencies]
-num-traits= "0.2.14"
+num-traits = { version = "0.2.14", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,13 @@
 //!     }
 //! }
 //! ```
+#![cfg_attr(not(std), no_std)]
 
 use num_traits::{
     ops::checked::{CheckedAdd, CheckedMul},
     Bounded, CheckedSub, One, Signed, Zero,
 };
-use std::{
+use core::{
     cmp::{max, min},
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
 };


### PR DESCRIPTION
This crate is fully no-std compatible, there is a change to how `num-traits` works (it pulls in std or libm) depending on std/no_std, so I added std as a feature and made that default to make sure existing behaviour is identical if not specifying `--no-default-features`