### PR TITLE
Optimize ASCII digit and hexdigit conversion by using subtraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 
 use num_traits::{
     ops::checked::{CheckedAdd, CheckedMul},
-    Bounded, CheckedSub, One, Signed, Zero,
+    Bounded, CheckedSub, FromPrimitive, One, Signed, Zero,
 };
 use core::{
     cmp::{max, min},
@@ -332,26 +332,18 @@ where
 /// ```
 pub fn ascii_to_digit<I>(character: u8) -> Option<I>
 where
-    I: Zero + One,
+    I: Zero + One + FromPrimitive,
 {
-    match character {
-        b'0' => Some(nth(0)),
-        b'1' => Some(nth(1)),
-        b'2' => Some(nth(2)),
-        b'3' => Some(nth(3)),
-        b'4' => Some(nth(4)),
-        b'5' => Some(nth(5)),
-        b'6' => Some(nth(6)),
-        b'7' => Some(nth(7)),
-        b'8' => Some(nth(8)),
-        b'9' => Some(nth(9)),
-        _ => None,
+    if (b'0'..=b'9').contains(&character) {
+        I::from_u8(character - b'0')
+    } else {
+        None
     }
 }
 
 impl<I> FromRadix10 for I
 where
-    I: Zero + One + AddAssign + MulAssign,
+    I: Zero + One + FromPrimitive + AddAssign + MulAssign,
 {
     fn from_radix_10(text: &[u8]) -> (Self, usize) {
         let mut index = 0;
@@ -371,7 +363,7 @@ where
 
 impl<I> FromRadix10Signed for I
 where
-    I: Zero + One + AddAssign + SubAssign + MulAssign,
+    I: Zero + One + AddAssign + SubAssign + MulAssign + FromPrimitive,
 {
     fn from_radix_10_signed(text: &[u8]) -> (Self, usize) {
         let mut index;
@@ -428,7 +420,8 @@ where
         + CheckedAdd
         + CheckedSub
         + CheckedMul
-        + MaxNumDigits,
+        + MaxNumDigits
+        + FromPrimitive,
 {
     fn from_radix_10_signed_checked(text: &[u8]) -> (Option<Self>, usize) {
         let mut index;
@@ -503,7 +496,7 @@ where
 
 impl<I> FromRadix10Checked for I
 where
-    I: Zero + One + FromRadix10 + CheckedMul + CheckedAdd + MaxNumDigits,
+    I: Zero + One + FromRadix10 + CheckedMul + CheckedAdd + MaxNumDigits + FromPrimitive,
 {
     fn from_radix_10_checked(text: &[u8]) -> (Option<I>, usize) {
         let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
@@ -526,32 +519,19 @@ where
 /// Converts an ascii character to digit
 fn ascii_to_hexdigit<I>(character: u8) -> Option<I>
 where
-    I: Zero + One,
+    I: Zero + One + FromPrimitive,
 {
     match character {
-        b'0' => Some(nth(0)),
-        b'1' => Some(nth(1)),
-        b'2' => Some(nth(2)),
-        b'3' => Some(nth(3)),
-        b'4' => Some(nth(4)),
-        b'5' => Some(nth(5)),
-        b'6' => Some(nth(6)),
-        b'7' => Some(nth(7)),
-        b'8' => Some(nth(8)),
-        b'9' => Some(nth(9)),
-        b'a' | b'A' => Some(nth(10)),
-        b'b' | b'B' => Some(nth(11)),
-        b'c' | b'C' => Some(nth(12)),
-        b'd' | b'D' => Some(nth(13)),
-        b'e' | b'E' => Some(nth(14)),
-        b'f' | b'F' => Some(nth(15)),
+        b'0'..=b'9' => I::from_u8(character - b'0'),
+        b'A'..=b'F' => I::from_u8(10 + (character - b'A')),
+        b'a'..=b'f' => I::from_u8(10 + (character - b'a')),
         _ => None,
     }
 }
 
 impl<I> FromRadix16 for I
 where
-    I: Zero + One + AddAssign + MulAssign,
+    I: Zero + One + FromPrimitive + AddAssign + MulAssign,
 {
     fn from_radix_16(text: &[u8]) -> (Self, usize) {
         let mut index = 0;
@@ -571,7 +551,7 @@ where
 
 impl<I> FromRadix16Checked for I
 where
-    I: Zero + One + FromRadix16 + CheckedMul + CheckedAdd + MaxNumDigits,
+    I: Zero + One + FromRadix16 + CheckedMul + CheckedAdd + MaxNumDigits + FromPrimitive,
 {
     fn from_radix_16_checked(text: &[u8]) -> (Option<I>, usize) {
         let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
@@ -683,5 +663,25 @@ mod test {
         assert_eq!((None, 4), u8::from_radix_16_checked(b"1000"));
         assert_eq!((Some(25), 2), u8::from_radix_16_checked(b"19"));
         assert_eq!((Some(25), 2), u8::from_radix_16_checked(b"19!Blub"));
+    }
+
+    #[test]
+    fn ascii_to_digit_check() {
+        for (decimal, byte) in (0..=9).zip(b'0'..=b'9') {
+            assert_eq!(Some(decimal), ascii_to_digit(byte));
+        }
+    }
+
+    #[test]
+    fn ascii_to_hexdigit_check() {
+        for (decimal, byte) in (0x0..=0x9).zip(b'0'..=b'9') {
+            assert_eq!(Some(decimal), ascii_to_hexdigit(byte));
+        }
+        for (decimal, byte) in (0xA..=0xF).zip(b'a'..=b'f') {
+            assert_eq!(Some(decimal), ascii_to_hexdigit(byte));
+        }
+        for (decimal, byte) in (0xA..=0xF).zip(b'A'..=b'F') {
+            assert_eq!(Some(decimal), ascii_to_hexdigit(byte));
+        }
     }
 }


### PR DESCRIPTION
Subtract digits by their "base" digit to simplify the number of match arms when converting from ASCII digit or hexdigit to u8
Use `FromPrimitive::from_u8` in `ascii_to_digit` after checking for valid ASCII digit range
Condense `ascii_to_hexdigit` match arms and convert with `from_u8`
Add `FromPrimitive` trait bound to required trait impls
Add tests to verify correct parsing of digits and hex digits

---

I saw some significant wins across the board with this on the benchmarks, hopefully it wasn't just my CPU. `ascii_to_hexdigit` showed the biggest improvements likely due to the simplification of match arm statements.

Unfortunately, the only way I could figure out how to do this involved adding the `FromPrimitive` trait bound from `num-traits` in several places. I think adding another trait bound to a public facing trait makes it a breaking change but I'm not sure. If there's another way to do this, I'd be glad to change it.