### PR TITLE
Fix broken example README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ use atoi::FromRadix10;
 fn atoi_with_rest<I: FromRadix10>(text: &[u8]) -> Option<(&[u8], I)> {
     match I::from_radix_10(text) {
         (_, 0) => None,
-        (n, used) => Some((&[used..], n)),
+        (n, used) => Some((&text[used..], n)),
     }
 }
 ```


### PR DESCRIPTION
The example to know how much of the input has been consumed wasn't compiling.

```rs
use atoi::FromRadix10;

/// Return the parsed integer and remaining slice if successful.
fn atoi_with_rest<I: FromRadix10>(text: &[u8]) -> Option<(&[u8], I)> {
    match I::from_radix_10(text) {
        (_, 0) => None,
        (n, used) => Some((&[used..], n)),
    }
}

fn main() {
    println!("{:?}", atoi_with_rest::<u32>(b"25aaa"));
}
```

![image](https://github.com/pacman82/atoi-rs/assets/47481450/70435efc-bcda-4c43-9796-9867ea4190d0)

Fixed it by adding the `text` variable at the right place (see commit).

(using the above main)
```
$ cargo run
[...]
Some(([97, 97, 97], 25))
```