### PR TITLE
integer

### DIFF
--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,0 +1,71 @@
+use crate::{
+    FromRadix10, FromRadix10Checked, FromRadix10Signed, FromRadix10SignedChecked, FromRadix16,
+    FromRadix16Checked, Integer, MaxNumDigits,
+};
+
+macro_rules! impl_traits_using_integer {
+    ($t:ident) => {
+        impl FromRadix10 for $t {
+            fn from_radix_10(text: &[u8]) -> (Self, usize) {
+                let (Integer(i), p) = Integer::<Self>::from_radix_10(text);
+                (i, p)
+            }
+        }
+
+        impl FromRadix10Signed for $t {
+            fn from_radix_10_signed(text: &[u8]) -> (Self, usize) {
+                let (Integer(i), p) = Integer::<Self>::from_radix_10_signed(text);
+                (i, p)
+            }
+        }
+
+        impl MaxNumDigits for $t {
+            fn max_num_digits(radix: Self) -> usize {
+                Integer::<Self>::max_num_digits(Integer(radix))
+            }
+
+            fn max_num_digits_negative(radix: Self) -> usize {
+                Integer::<Self>::max_num_digits_negative(Integer(radix))
+            }
+        }
+
+        impl FromRadix10Checked for $t {
+            fn from_radix_10_checked(text: &[u8]) -> (Option<Self>, usize) {
+                let (o, p) = Integer::<Self>::from_radix_10_checked(text);
+                (o.map(|i| i.0), p)
+            }
+        }
+
+        impl FromRadix10SignedChecked for $t {
+            fn from_radix_10_signed_checked(text: &[u8]) -> (Option<Self>, usize) {
+                let (o, p) = Integer::<Self>::from_radix_10_signed_checked(text);
+                (o.map(|i| i.0), p)
+            }
+        }
+
+        impl FromRadix16 for $t {
+            fn from_radix_16(text: &[u8]) -> (Self, usize) {
+                let (Integer(i), p) = Integer::<Self>::from_radix_16(text);
+                (i, p)
+            }
+        }
+
+        impl FromRadix16Checked for $t {
+            fn from_radix_16_checked(text: &[u8]) -> (Option<Self>, usize) {
+                let (o, p) = Integer::<Self>::from_radix_16_checked(text);
+                (o.map(|i| i.0), p)
+            }
+        }
+    };
+}
+
+impl_traits_using_integer!(i8);
+impl_traits_using_integer!(u8);
+impl_traits_using_integer!(i16);
+impl_traits_using_integer!(u16);
+impl_traits_using_integer!(i32);
+impl_traits_using_integer!(u32);
+impl_traits_using_integer!(i64);
+impl_traits_using_integer!(u64);
+impl_traits_using_integer!(i128);
+impl_traits_using_integer!(u128);

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -108,8 +108,73 @@ macro_rules! impl_traits_using_integer {
 
         impl FromRadix10SignedChecked for $t {
             fn from_radix_10_signed_checked(text: &[u8]) -> (Option<Self>, usize) {
-                let (o, p) = Integer::<Self>::from_radix_10_signed_checked(text);
-                (o.map(|i| i.0), p)
+                let mut index;
+                let mut number = 0;
+
+                let (sign, offset) = text
+                    .first()
+                    .and_then(|&byte| Sign::try_from(byte))
+                    .map(|sign| (sign, 1))
+                    .unwrap_or((Sign::Plus, 0));
+
+                index = offset;
+
+                // Having two dedicated loops for both the negative and the nonnegative case is rather
+                // verbose, yet performed up to 40% better then a more terse single loop with
+                // `number += digit * signum`.
+
+                match sign {
+                    Sign::Plus => {
+                        let max_safe_digits = max(1, $t::max_num_digits(10)) - 1;
+                        let max_safe_index = min(text.len(), max_safe_digits + offset);
+                        while index != max_safe_index {
+                            if let Some(digit) = $t::from_digit(text[index]) {
+                                number *= 10;
+                                number += digit;
+                                index += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        // We parsed the digits, which do not need checking now lets see the next one:
+                        let mut number = Some(number);
+                        while index != text.len() {
+                            if let Some(digit) = $t::from_digit(text[index]) {
+                                number = number.and_then(|n| n.checked_mul(10));
+                                number = number.and_then(|n| n.checked_add(digit));
+                                index += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        (number, index)
+                    }
+                    Sign::Minus => {
+                        let max_safe_digits = max(1, $t::max_num_digits_negative(10)) - 1;
+                        let max_safe_index = min(text.len(), max_safe_digits + offset);
+                        while index != max_safe_index {
+                            if let Some(digit) = $t::from_digit(text[index]) {
+                                number *= 10;
+                                number -= digit;
+                                index += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        // We parsed the digits, which do not need checking now lets see the next one:
+                        let mut number = Some(number);
+                        while index != text.len() {
+                            if let Some(digit) = $t::from_digit(text[index]) {
+                                number = number.and_then(|n| n.checked_mul(10));
+                                number = number.and_then(|n| n.checked_sub(digit));
+                                index += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        (number, index)
+                    }
+                }
             }
         }
 
@@ -132,8 +197,21 @@ macro_rules! impl_traits_using_integer {
 
         impl FromRadix16Checked for $t {
             fn from_radix_16_checked(text: &[u8]) -> (Option<Self>, usize) {
-                let (o, p) = Integer::<Self>::from_radix_16_checked(text);
-                (o.map(|i| i.0), p)
+                let max_safe_digits = max(1, $t::max_num_digits_negative(16)) - 1;
+                let (number, mut index) =
+                    $t::from_radix_16(&text[..min(text.len(), max_safe_digits)]);
+                let mut number = Some(number);
+                // We parsed the digits, which do not need checking now lets see the next one:
+                while index != text.len() {
+                    if let Some(digit) = $t::from_hex_digit(text[index]) {
+                        number = number.and_then(|n| n.checked_mul(16));
+                        number = number.and_then(|n| n.checked_add(digit));
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                (number, index)
             }
         }
 

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -4,8 +4,9 @@
 //! A generic implementation for "any integer" can still be invoked using the `Integer` wrapper.
 
 use crate::{
-    FromDigit, FromRadix10, FromRadix10Checked, FromRadix10Signed, FromRadix10SignedChecked,
-    FromRadix16, FromRadix16Checked, Integer, MaxNumDigits, ascii_to_digit,
+    FromDigit, FromHexDigit, FromRadix10, FromRadix10Checked, FromRadix10Signed,
+    FromRadix10SignedChecked, FromRadix16, FromRadix16Checked, Integer, MaxNumDigits,
+    ascii_to_digit,
 };
 
 macro_rules! impl_traits_using_integer {
@@ -60,8 +61,18 @@ macro_rules! impl_traits_using_integer {
 
         impl FromRadix16 for $t {
             fn from_radix_16(text: &[u8]) -> (Self, usize) {
-                let (Integer(i), p) = Integer::<Self>::from_radix_16(text);
-                (i, p)
+                let mut index = 0;
+                let mut number = 0;
+                while index != text.len() {
+                    if let Some(digit) = $t::from_hex_digit(text[index]) {
+                        number *= 16;
+                        number += digit;
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                (number, index)
             }
         }
 
@@ -85,6 +96,30 @@ macro_rules! impl_traits_using_integer {
                     b'7' => Some(7),
                     b'8' => Some(8),
                     b'9' => Some(9),
+                    _ => None,
+                }
+            }
+        }
+
+        impl FromHexDigit for $t {
+            fn from_hex_digit(digit: u8) -> Option<Self> {
+                match digit {
+                    b'0' => Some(0),
+                    b'1' => Some(1),
+                    b'2' => Some(2),
+                    b'3' => Some(3),
+                    b'4' => Some(4),
+                    b'5' => Some(5),
+                    b'6' => Some(6),
+                    b'7' => Some(7),
+                    b'8' => Some(8),
+                    b'9' => Some(9),
+                    b'a' | b'A' => Some(10),
+                    b'b' | b'B' => Some(11),
+                    b'c' | b'C' => Some(12),
+                    b'd' | b'D' => Some(13),
+                    b'e' | b'E' => Some(14),
+                    b'f' | b'F' => Some(15),
                     _ => None,
                 }
             }

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -9,6 +9,8 @@ use crate::{
     ascii_to_digit,
 };
 
+use num_traits::FromPrimitive;
+
 use core::cmp::{max, min};
 
 macro_rules! impl_traits_using_integer {
@@ -235,24 +237,21 @@ macro_rules! impl_traits_using_integer {
 
         impl FromHexDigit for $t {
             fn from_hex_digit(digit: u8) -> Option<Self> {
-                match digit {
-                    b'0' => Some(0),
-                    b'1' => Some(1),
-                    b'2' => Some(2),
-                    b'3' => Some(3),
-                    b'4' => Some(4),
-                    b'5' => Some(5),
-                    b'6' => Some(6),
-                    b'7' => Some(7),
-                    b'8' => Some(8),
-                    b'9' => Some(9),
-                    b'a' | b'A' => Some(10),
-                    b'b' | b'B' => Some(11),
-                    b'c' | b'C' => Some(12),
-                    b'd' | b'D' => Some(13),
-                    b'e' | b'E' => Some(14),
-                    b'f' | b'F' => Some(15),
-                    _ => None,
+                // Unsetting the 6th bit converts ASCII alphabetic lowercase to uppercase.
+                //
+                // b'A' = 0b_0100_0001 (decimal 65), b'F' = 0b_0100_0110 (decimal 70)
+                // b'a' = 0b_0110_0001 (decimal 97), b'f' = 0b_0110_0110 (decimal 102)
+                // b'a' & 0b_1101_1111 converts 'a' to 'A'.
+                let mask = 0b_1101_1111;
+
+                if matches!(digit, b'0'..=b'9') {
+                    $t::from_u8(digit - b'0')
+                } else if matches!(digit & mask, b'A'..=b'F') {
+                    // Subtract 55 from the result to map the character to its hexadecimal
+                    // value: (65 to 70) - 55 => 10 to 15
+                    $t::from_u8((digit & mask) - 55)
+                } else {
+                    None
                 }
             }
         }

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -5,12 +5,12 @@
 
 use crate::{
     FromDigit, FromHexDigit, FromRadix10, FromRadix10Checked, FromRadix10Signed,
-    FromRadix10SignedChecked, FromRadix16, FromRadix16Checked, Integer, MaxNumDigits, Sign,
+    FromRadix10SignedChecked, FromRadix16, FromRadix16Checked, Sign,
 };
 
 use num_traits::FromPrimitive;
 
-use core::cmp::{max, min};
+use core::cmp::min;
 
 macro_rules! impl_traits_using_integer {
     ($t:ident) => {
@@ -77,21 +77,11 @@ macro_rules! impl_traits_using_integer {
             }
         }
 
-        impl MaxNumDigits for $t {
-            fn max_num_digits(radix: Self) -> usize {
-                Integer::<Self>::max_num_digits(Integer(radix))
-            }
-
-            fn max_num_digits_negative(radix: Self) -> usize {
-                Integer::<Self>::max_num_digits_negative(Integer(radix))
-            }
-        }
-
         impl FromRadix10Checked for $t {
             fn from_radix_10_checked(text: &[u8]) -> (Option<Self>, usize) {
-                let max_safe_digits = max(1, $t::max_num_digits_negative(10)) - 1;
-                let (number, mut index) =
-                    $t::from_radix_10(&text[..min(text.len(), max_safe_digits)]);
+                let (number, mut index) = $t::from_radix_10(
+                    &text[..min(text.len(), $t::NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10)],
+                );
                 let mut number = Some(number);
                 // We parsed the digits, which do not need checking now lets see the next one:
                 while index != text.len() {
@@ -126,8 +116,10 @@ macro_rules! impl_traits_using_integer {
 
                 match sign {
                     Sign::Plus => {
-                        let max_safe_digits = max(1, $t::max_num_digits(10)) - 1;
-                        let max_safe_index = min(text.len(), max_safe_digits + offset);
+                        let max_safe_index = min(
+                            text.len(),
+                            $t::NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10 + offset,
+                        );
                         while index != max_safe_index {
                             if let Some(digit) = $t::from_digit(text[index]) {
                                 number *= 10;
@@ -151,8 +143,10 @@ macro_rules! impl_traits_using_integer {
                         (number, index)
                     }
                     Sign::Minus => {
-                        let max_safe_digits = max(1, $t::max_num_digits_negative(10)) - 1;
-                        let max_safe_index = min(text.len(), max_safe_digits + offset);
+                        let max_safe_index = min(
+                            text.len(),
+                            $t::NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10 + offset,
+                        );
                         while index != max_safe_index {
                             if let Some(digit) = $t::from_digit(text[index]) {
                                 number *= 10;
@@ -198,9 +192,9 @@ macro_rules! impl_traits_using_integer {
 
         impl FromRadix16Checked for $t {
             fn from_radix_16_checked(text: &[u8]) -> (Option<Self>, usize) {
-                let max_safe_digits = max(1, $t::max_num_digits_negative(16)) - 1;
-                let (number, mut index) =
-                    $t::from_radix_16(&text[..min(text.len(), max_safe_digits)]);
+                let (number, mut index) = $t::from_radix_16(
+                    &text[..min(text.len(), $t::NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16)],
+                );
                 let mut number = Some(number);
                 // We parsed the digits, which do not need checking now lets see the next one:
                 while index != text.len() {
@@ -267,3 +261,100 @@ impl_traits_using_integer!(i64);
 impl_traits_using_integer!(u64);
 impl_traits_using_integer!(i128);
 impl_traits_using_integer!(u128);
+
+// Num digits which are safe to parse without overflow
+trait SafeDigits {
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize;
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize;
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize;
+}
+
+impl SafeDigits for i8 {
+    // 127
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 2;
+    // 7F
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 1;
+    // -128
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 2;
+}
+
+impl SafeDigits for u8 {
+    // 255
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 2;
+    // FF
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 2;
+    // 0
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 0;
+}
+
+impl SafeDigits for i16 {
+    // 32767
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 4;
+    // 7FFF
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 3;
+    // -32768
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 5;
+}
+
+impl SafeDigits for u16 {
+    // 65535
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 4;
+    // FFFF
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 4;
+    // 0
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 0;
+}
+
+impl SafeDigits for i32 {
+    // 2147483647
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 9;
+    // 7FFFFFFF
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 7;
+    // -2147483648
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 9;
+}
+
+impl SafeDigits for u32 {
+    // 4294967295
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 9;
+    // FFFFFFFF
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 8;
+    // 0
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 0;
+}
+
+impl SafeDigits for i64 {
+    // 9223372036854775807
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 18;
+    // 7FFFFFFFFFFFFFFF
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 15;
+    // -9223372036854775808
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 18;
+}
+
+impl SafeDigits for u64 {
+    // 18446744073709551615
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 19;
+    // FFFFFFFFFFFFFFFF
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 16;
+    // 0
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 0;
+}
+
+impl SafeDigits for i128 {
+    // 170141183460469231731687303715884105727
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 38;
+    // 7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 31;
+    // -170141183460469231731687303715884105728
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 38;
+}
+
+impl SafeDigits for u128 {
+    // 340282366920938463463374607431768211455
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10: usize = 38;
+    // FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+    const NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16: usize = 32;
+    // 0
+    const NUM_SAFE_DIGITS_NON_POSITIVE_RADIX_10: usize = 0;
+}

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -5,9 +5,11 @@
 
 use crate::{
     FromDigit, FromHexDigit, FromRadix10, FromRadix10Checked, FromRadix10Signed,
-    FromRadix10SignedChecked, FromRadix16, FromRadix16Checked, Integer, MaxNumDigits,
+    FromRadix10SignedChecked, FromRadix16, FromRadix16Checked, Integer, MaxNumDigits, Sign,
     ascii_to_digit,
 };
+
+use core::cmp::{max, min};
 
 macro_rules! impl_traits_using_integer {
     ($t:ident) => {
@@ -30,8 +32,47 @@ macro_rules! impl_traits_using_integer {
 
         impl FromRadix10Signed for $t {
             fn from_radix_10_signed(text: &[u8]) -> (Self, usize) {
-                let (Integer(i), p) = Integer::<Self>::from_radix_10_signed(text);
-                (i, p)
+                let mut index;
+                let mut number = 0;
+
+                let (sign, offset) = text
+                    .first()
+                    .and_then(|&byte| Sign::try_from(byte))
+                    .map(|sign| (sign, 1))
+                    .unwrap_or((Sign::Plus, 0));
+
+                index = offset;
+
+                // Having two dedicated loops for both the negative and the nonnegative case is rather
+                // verbose, yet performed up to 40% better then a more terse single loop with
+                // `number += digit * signum`.
+
+                match sign {
+                    Sign::Plus => {
+                        while index != text.len() {
+                            if let Some(digit) = $t::from_digit(text[index]) {
+                                number *= 10;
+                                number += digit;
+                                index += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                    Sign::Minus => {
+                        while index != text.len() {
+                            if let Some(digit) = $t::from_digit(text[index]) {
+                                number *= 10;
+                                number -= digit;
+                                index += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                (number, index)
             }
         }
 
@@ -47,8 +88,21 @@ macro_rules! impl_traits_using_integer {
 
         impl FromRadix10Checked for $t {
             fn from_radix_10_checked(text: &[u8]) -> (Option<Self>, usize) {
-                let (o, p) = Integer::<Self>::from_radix_10_checked(text);
-                (o.map(|i| i.0), p)
+                let max_safe_digits = max(1, $t::max_num_digits_negative(10)) - 1;
+                let (number, mut index) =
+                    $t::from_radix_10(&text[..min(text.len(), max_safe_digits)]);
+                let mut number = Some(number);
+                // We parsed the digits, which do not need checking now lets see the next one:
+                while index != text.len() {
+                    if let Some(digit) = $t::from_digit(text[index]) {
+                        number = number.and_then(|n| n.checked_mul(10));
+                        number = number.and_then(|n| n.checked_add(digit));
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                (number, index)
             }
         }
 

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,14 +1,29 @@
+//! Implementation for numerical types native to Rust. Currently we use macros instead of one
+//! generic implementation relying on traits. This way we can better specialize some implementations
+//! in the future without relying on specializations for generic implementation to become stable.
+//! A generic implementation for "any integer" can still be invoked using the `Integer` wrapper.
+
 use crate::{
-    FromRadix10, FromRadix10Checked, FromRadix10Signed, FromRadix10SignedChecked, FromRadix16,
-    FromRadix16Checked, Integer, MaxNumDigits,
+    FromDigit, FromRadix10, FromRadix10Checked, FromRadix10Signed, FromRadix10SignedChecked,
+    FromRadix16, FromRadix16Checked, Integer, MaxNumDigits, ascii_to_digit,
 };
 
 macro_rules! impl_traits_using_integer {
     ($t:ident) => {
         impl FromRadix10 for $t {
             fn from_radix_10(text: &[u8]) -> (Self, usize) {
-                let (Integer(i), p) = Integer::<Self>::from_radix_10(text);
-                (i, p)
+                let mut index = 0;
+                let mut number = 0;
+                while index != text.len() {
+                    if let Some(digit) = ascii_to_digit::<$t>(text[index]) {
+                        number *= 10;
+                        number += digit;
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                (number, index)
             }
         }
 
@@ -54,6 +69,24 @@ macro_rules! impl_traits_using_integer {
             fn from_radix_16_checked(text: &[u8]) -> (Option<Self>, usize) {
                 let (o, p) = Integer::<Self>::from_radix_16_checked(text);
                 (o.map(|i| i.0), p)
+            }
+        }
+
+        impl FromDigit for $t {
+            fn from_digit(digit: u8) -> Option<Self> {
+                match digit {
+                    b'0' => Some(0),
+                    b'1' => Some(1),
+                    b'2' => Some(2),
+                    b'3' => Some(3),
+                    b'4' => Some(4),
+                    b'5' => Some(5),
+                    b'6' => Some(6),
+                    b'7' => Some(7),
+                    b'8' => Some(8),
+                    b'9' => Some(9),
+                    _ => None,
+                }
             }
         }
     };

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -15,6 +15,7 @@ use core::cmp::min;
 macro_rules! impl_traits_using_integer {
     ($t:ident) => {
         impl FromRadix10 for $t {
+            #[inline]
             fn from_radix_10(text: &[u8]) -> (Self, usize) {
                 let mut index = 0;
                 let mut number = 0;
@@ -32,6 +33,7 @@ macro_rules! impl_traits_using_integer {
         }
 
         impl FromRadix10Signed for $t {
+            #[inline]
             fn from_radix_10_signed(text: &[u8]) -> (Self, usize) {
                 let mut index;
                 let mut number = 0;
@@ -78,6 +80,7 @@ macro_rules! impl_traits_using_integer {
         }
 
         impl FromRadix10Checked for $t {
+            #[inline]
             fn from_radix_10_checked(text: &[u8]) -> (Option<Self>, usize) {
                 let (number, mut index) = $t::from_radix_10(
                     &text[..min(text.len(), $t::NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_10)],
@@ -98,6 +101,7 @@ macro_rules! impl_traits_using_integer {
         }
 
         impl FromRadix10SignedChecked for $t {
+            #[inline]
             fn from_radix_10_signed_checked(text: &[u8]) -> (Option<Self>, usize) {
                 let mut index;
                 let mut number = 0;
@@ -174,6 +178,7 @@ macro_rules! impl_traits_using_integer {
         }
 
         impl FromRadix16 for $t {
+            #[inline]
             fn from_radix_16(text: &[u8]) -> (Self, usize) {
                 let mut index = 0;
                 let mut number = 0;
@@ -191,6 +196,7 @@ macro_rules! impl_traits_using_integer {
         }
 
         impl FromRadix16Checked for $t {
+            #[inline]
             fn from_radix_16_checked(text: &[u8]) -> (Option<Self>, usize) {
                 let (number, mut index) = $t::from_radix_16(
                     &text[..min(text.len(), $t::NUM_SAFE_DIGITS_NON_NEGATIVE_RADIX_16)],
@@ -211,6 +217,7 @@ macro_rules! impl_traits_using_integer {
         }
 
         impl FromDigit for $t {
+            #[inline]
             fn from_digit(digit: u8) -> Option<Self> {
                 match digit {
                     b'0' => Some(0),
@@ -229,6 +236,7 @@ macro_rules! impl_traits_using_integer {
         }
 
         impl FromHexDigit for $t {
+            #[inline]
             fn from_hex_digit(digit: u8) -> Option<Self> {
                 // Unsetting the 6th bit converts ASCII alphabetic lowercase to uppercase.
                 //

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -6,7 +6,6 @@
 use crate::{
     FromDigit, FromHexDigit, FromRadix10, FromRadix10Checked, FromRadix10Signed,
     FromRadix10SignedChecked, FromRadix16, FromRadix16Checked, Integer, MaxNumDigits, Sign,
-    ascii_to_digit,
 };
 
 use num_traits::FromPrimitive;
@@ -20,7 +19,7 @@ macro_rules! impl_traits_using_integer {
                 let mut index = 0;
                 let mut number = 0;
                 while index != text.len() {
-                    if let Some(digit) = ascii_to_digit::<$t>(text[index]) {
+                    if let Some(digit) = $t::from_digit(text[index]) {
                         number *= 10;
                         number += digit;
                         index += 1;

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -274,7 +274,7 @@ where
     I: Zero + One + FromRadix16 + CheckedMul + CheckedAdd + MaxNumDigits,
 {
     fn from_radix_16_checked(text: &[u8]) -> (Option<Self>, usize) {
-        let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
+        let max_safe_digits = max(1, I::max_num_digits_negative(nth(16))) - 1;
         let (number, mut index) = I::from_radix_16(&text[..min(text.len(), max_safe_digits)]);
         let mut number = Some(number);
         // We parsed the digits, which do not need checking now lets see the next one:

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,8 +1,14 @@
-use core::{ops::{AddAssign, MulAssign, SubAssign, DivAssign}, cmp::{max, min}};
+use core::{
+    cmp::{max, min},
+    ops::{AddAssign, DivAssign, MulAssign, SubAssign},
+};
 
-use num_traits::{Zero, One, CheckedAdd, CheckedSub, CheckedMul, Bounded};
+use num_traits::{Bounded, CheckedAdd, CheckedMul, CheckedSub, One, Zero};
 
-use crate::{FromRadix10, FromRadix10Signed, Sign, FromRadix10SignedChecked, MaxNumDigits, FromRadix10Checked, FromRadix16, FromRadix16Checked};
+use crate::{
+    FromDigit, FromRadix10, FromRadix10Checked, FromRadix10Signed, FromRadix10SignedChecked,
+    FromRadix16, FromRadix16Checked, MaxNumDigits, Sign,
+};
 
 /// Wrapper which implements the traits [`crate::FromRadix10`], [`crate::FromRadix10Checked`],
 /// [`crate::FromRadix16`] and [`crate::FromRadix16Checked`] for any inductive type. I.e. a type
@@ -17,9 +23,9 @@ where
         let mut index = 0;
         let mut number = I::zero();
         while index != text.len() {
-            if let Some(digit) = ascii_to_digit(text[index]) {
+            if let Some(digit) = Integer::<I>::from_digit(text[index]) {
                 number *= nth(10);
-                number += digit;
+                number += digit.0;
                 index += 1;
             } else {
                 break;
@@ -52,9 +58,9 @@ where
         match sign {
             Sign::Plus => {
                 while index != text.len() {
-                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
+                    if let Some(digit) = Integer::<I>::from_digit(text[index]) {
                         number *= nth(10);
-                        number += digit;
+                        number += digit.0;
                         index += 1;
                     } else {
                         break;
@@ -63,9 +69,9 @@ where
             }
             Sign::Minus => {
                 while index != text.len() {
-                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
+                    if let Some(digit) = Integer::<I>::from_digit(text[index]) {
                         number *= nth(10);
-                        number -= digit;
+                        number -= digit.0;
                         index += 1;
                     } else {
                         break;
@@ -78,31 +84,24 @@ where
     }
 }
 
-/// Converts an ascii character to digit
-///
-/// # Example
-///
-/// ```
-/// use atoi::ascii_to_digit;
-/// assert_eq!(Some(5), ascii_to_digit(b'5'));
-/// assert_eq!(None, ascii_to_digit::<u32>(b'x'));
-/// ```
-pub fn ascii_to_digit<I>(character: u8) -> Option<I>
+impl<I> FromDigit for Integer<I>
 where
     I: Zero + One,
 {
-    match character {
-        b'0' => Some(nth(0)),
-        b'1' => Some(nth(1)),
-        b'2' => Some(nth(2)),
-        b'3' => Some(nth(3)),
-        b'4' => Some(nth(4)),
-        b'5' => Some(nth(5)),
-        b'6' => Some(nth(6)),
-        b'7' => Some(nth(7)),
-        b'8' => Some(nth(8)),
-        b'9' => Some(nth(9)),
-        _ => None,
+    fn from_digit(digit: u8) -> Option<Self> {
+        match digit {
+            b'0' => Some(Integer(nth(0))),
+            b'1' => Some(Integer(nth(1))),
+            b'2' => Some(Integer(nth(2))),
+            b'3' => Some(Integer(nth(3))),
+            b'4' => Some(Integer(nth(4))),
+            b'5' => Some(Integer(nth(5))),
+            b'6' => Some(Integer(nth(6))),
+            b'7' => Some(Integer(nth(7))),
+            b'8' => Some(Integer(nth(8))),
+            b'9' => Some(Integer(nth(9))),
+            _ => None,
+        }
     }
 }
 
@@ -152,9 +151,9 @@ where
                 let max_safe_digits = max(1, I::max_num_digits(nth(10))) - 1;
                 let max_safe_index = min(text.len(), max_safe_digits + offset);
                 while index != max_safe_index {
-                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
+                    if let Some(digit) = Integer::<I>::from_digit(text[index]) {
                         number *= nth(10);
-                        number += digit;
+                        number += digit.0;
                         index += 1;
                     } else {
                         break;
@@ -163,9 +162,9 @@ where
                 // We parsed the digits, which do not need checking now lets see the next one:
                 let mut number = Some(number);
                 while index != text.len() {
-                    if let Some(digit) = ascii_to_digit(text[index]) {
+                    if let Some(digit) = Integer::<I>::from_digit(text[index]) {
                         number = number.and_then(|n| n.checked_mul(&nth(10)));
-                        number = number.and_then(|n| n.checked_add(&digit));
+                        number = number.and_then(|n| n.checked_add(&digit.0));
                         index += 1;
                     } else {
                         break;
@@ -177,9 +176,9 @@ where
                 let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
                 let max_safe_index = min(text.len(), max_safe_digits + offset);
                 while index != max_safe_index {
-                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
+                    if let Some(digit) = Integer::<I>::from_digit(text[index]) {
                         number *= nth(10);
-                        number -= digit;
+                        number -= digit.0;
                         index += 1;
                     } else {
                         break;
@@ -188,9 +187,9 @@ where
                 // We parsed the digits, which do not need checking now lets see the next one:
                 let mut number = Some(number);
                 while index != text.len() {
-                    if let Some(digit) = ascii_to_digit(text[index]) {
+                    if let Some(digit) = Integer::<I>::from_digit(text[index]) {
                         number = number.and_then(|n| n.checked_mul(&nth(10)));
-                        number = number.and_then(|n| n.checked_sub(&digit));
+                        number = number.and_then(|n| n.checked_sub(&digit.0));
                         index += 1;
                     } else {
                         break;
@@ -212,9 +211,9 @@ where
         let mut number = Some(number);
         // We parsed the digits, which do not need checking now lets see the next one:
         while index != text.len() {
-            if let Some(digit) = ascii_to_digit(text[index]) {
+            if let Some(digit) = Integer::<I>::from_digit(text[index]) {
                 number = number.and_then(|n| n.checked_mul(&nth(10)));
-                number = number.and_then(|n| n.checked_add(&digit));
+                number = number.and_then(|n| n.checked_add(&digit.0));
                 index += 1;
             } else {
                 break;

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,0 +1,322 @@
+use core::{ops::{AddAssign, MulAssign, SubAssign, DivAssign}, cmp::{max, min}};
+
+use num_traits::{Zero, One, CheckedAdd, CheckedSub, CheckedMul, Bounded};
+
+use crate::{FromRadix10, FromRadix10Signed, Sign, FromRadix10SignedChecked, MaxNumDigits, FromRadix10Checked, FromRadix16, FromRadix16Checked};
+
+/// Wrapper which implements the traits [`crate::FromRadix10`], [`crate::FromRadix10Checked`],
+/// [`crate::FromRadix16`] and [`crate::FromRadix16Checked`] for any inductive type. I.e. a type
+/// implementing [`One`], [`Zero`], `+=` and `*=`.
+pub struct Integer<I>(pub I);
+
+impl<I> FromRadix10 for Integer<I>
+where
+    I: Zero + One + AddAssign + MulAssign,
+{
+    fn from_radix_10(text: &[u8]) -> (Self, usize) {
+        let mut index = 0;
+        let mut number = I::zero();
+        while index != text.len() {
+            if let Some(digit) = ascii_to_digit(text[index]) {
+                number *= nth(10);
+                number += digit;
+                index += 1;
+            } else {
+                break;
+            }
+        }
+        (Integer(number), index)
+    }
+}
+
+impl<I> FromRadix10Signed for Integer<I>
+where
+    I: Zero + One + AddAssign + SubAssign + MulAssign,
+{
+    fn from_radix_10_signed(text: &[u8]) -> (Self, usize) {
+        let mut index;
+        let mut number = I::zero();
+
+        let (sign, offset) = text
+            .first()
+            .and_then(|&byte| Sign::try_from(byte))
+            .map(|sign| (sign, 1))
+            .unwrap_or((Sign::Plus, 0));
+
+        index = offset;
+
+        // Having two dedicated loops for both the negative and the nonnegative case is rather
+        // verbose, yet performed up to 40% better then a more terse single loop with
+        // `number += digit * signum`.
+
+        match sign {
+            Sign::Plus => {
+                while index != text.len() {
+                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
+                        number *= nth(10);
+                        number += digit;
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            Sign::Minus => {
+                while index != text.len() {
+                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
+                        number *= nth(10);
+                        number -= digit;
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        (Integer(number), index)
+    }
+}
+
+/// Converts an ascii character to digit
+///
+/// # Example
+///
+/// ```
+/// use atoi::ascii_to_digit;
+/// assert_eq!(Some(5), ascii_to_digit(b'5'));
+/// assert_eq!(None, ascii_to_digit::<u32>(b'x'));
+/// ```
+pub fn ascii_to_digit<I>(character: u8) -> Option<I>
+where
+    I: Zero + One,
+{
+    match character {
+        b'0' => Some(nth(0)),
+        b'1' => Some(nth(1)),
+        b'2' => Some(nth(2)),
+        b'3' => Some(nth(3)),
+        b'4' => Some(nth(4)),
+        b'5' => Some(nth(5)),
+        b'6' => Some(nth(6)),
+        b'7' => Some(nth(7)),
+        b'8' => Some(nth(8)),
+        b'9' => Some(nth(9)),
+        _ => None,
+    }
+}
+
+// At least for primitive types this function does not incur runtime costs, since it is only called
+// with constants
+fn nth<I>(n: u8) -> I
+where
+    I: Zero + One,
+{
+    let mut i = I::zero();
+    for _ in 0..n {
+        i = i + I::one();
+    }
+    i
+}
+
+impl<I> FromRadix10SignedChecked for Integer<I>
+where
+    I: Zero
+        + One
+        + AddAssign
+        + MulAssign
+        + SubAssign
+        + CheckedAdd
+        + CheckedSub
+        + CheckedMul
+        + MaxNumDigits,
+{
+    fn from_radix_10_signed_checked(text: &[u8]) -> (Option<Self>, usize) {
+        let mut index;
+        let mut number = I::zero();
+
+        let (sign, offset) = text
+            .first()
+            .and_then(|&byte| Sign::try_from(byte))
+            .map(|sign| (sign, 1))
+            .unwrap_or((Sign::Plus, 0));
+
+        index = offset;
+
+        // Having two dedicated loops for both the negative and the nonnegative case is rather
+        // verbose, yet performed up to 40% better then a more terse single loop with
+        // `number += digit * signum`.
+
+        match sign {
+            Sign::Plus => {
+                let max_safe_digits = max(1, I::max_num_digits(nth(10))) - 1;
+                let max_safe_index = min(text.len(), max_safe_digits + offset);
+                while index != max_safe_index {
+                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
+                        number *= nth(10);
+                        number += digit;
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                // We parsed the digits, which do not need checking now lets see the next one:
+                let mut number = Some(number);
+                while index != text.len() {
+                    if let Some(digit) = ascii_to_digit(text[index]) {
+                        number = number.and_then(|n| n.checked_mul(&nth(10)));
+                        number = number.and_then(|n| n.checked_add(&digit));
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                (number.map(Integer), index)
+            }
+            Sign::Minus => {
+                let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
+                let max_safe_index = min(text.len(), max_safe_digits + offset);
+                while index != max_safe_index {
+                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
+                        number *= nth(10);
+                        number -= digit;
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                // We parsed the digits, which do not need checking now lets see the next one:
+                let mut number = Some(number);
+                while index != text.len() {
+                    if let Some(digit) = ascii_to_digit(text[index]) {
+                        number = number.and_then(|n| n.checked_mul(&nth(10)));
+                        number = number.and_then(|n| n.checked_sub(&digit));
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                (number.map(Integer), index)
+            }
+        }
+    }
+}
+
+impl<I> FromRadix10Checked for Integer<I>
+where
+    I: Zero + One + FromRadix10 + CheckedMul + CheckedAdd + MaxNumDigits,
+{
+    fn from_radix_10_checked(text: &[u8]) -> (Option<Self>, usize) {
+        let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
+        let (number, mut index) = I::from_radix_10(&text[..min(text.len(), max_safe_digits)]);
+        let mut number = Some(number);
+        // We parsed the digits, which do not need checking now lets see the next one:
+        while index != text.len() {
+            if let Some(digit) = ascii_to_digit(text[index]) {
+                number = number.and_then(|n| n.checked_mul(&nth(10)));
+                number = number.and_then(|n| n.checked_add(&digit));
+                index += 1;
+            } else {
+                break;
+            }
+        }
+        (number.map(Integer), index)
+    }
+}
+
+/// Converts an ascii character to digit
+fn ascii_to_hexdigit<I>(character: u8) -> Option<I>
+where
+    I: Zero + One,
+{
+    match character {
+        b'0' => Some(nth(0)),
+        b'1' => Some(nth(1)),
+        b'2' => Some(nth(2)),
+        b'3' => Some(nth(3)),
+        b'4' => Some(nth(4)),
+        b'5' => Some(nth(5)),
+        b'6' => Some(nth(6)),
+        b'7' => Some(nth(7)),
+        b'8' => Some(nth(8)),
+        b'9' => Some(nth(9)),
+        b'a' | b'A' => Some(nth(10)),
+        b'b' | b'B' => Some(nth(11)),
+        b'c' | b'C' => Some(nth(12)),
+        b'd' | b'D' => Some(nth(13)),
+        b'e' | b'E' => Some(nth(14)),
+        b'f' | b'F' => Some(nth(15)),
+        _ => None,
+    }
+}
+
+impl<I> FromRadix16 for Integer<I>
+where
+    I: Zero + One + AddAssign + MulAssign,
+{
+    fn from_radix_16(text: &[u8]) -> (Self, usize) {
+        let mut index = 0;
+        let mut number = I::zero();
+        while index != text.len() {
+            if let Some(digit) = ascii_to_hexdigit(text[index]) {
+                number *= nth(16);
+                number += digit;
+                index += 1;
+            } else {
+                break;
+            }
+        }
+        (Integer(number), index)
+    }
+}
+
+impl<I> FromRadix16Checked for Integer<I>
+where
+    I: Zero + One + FromRadix16 + CheckedMul + CheckedAdd + MaxNumDigits,
+{
+    fn from_radix_16_checked(text: &[u8]) -> (Option<Self>, usize) {
+        let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
+        let (number, mut index) = I::from_radix_16(&text[..min(text.len(), max_safe_digits)]);
+        let mut number = Some(number);
+        // We parsed the digits, which do not need checking now lets see the next one:
+        while index != text.len() {
+            if let Some(digit) = ascii_to_hexdigit(text[index]) {
+                number = number.and_then(|n| n.checked_mul(&nth(16)));
+                number = number.and_then(|n| n.checked_add(&digit));
+                index += 1;
+            } else {
+                break;
+            }
+        }
+        (number.map(Integer), index)
+    }
+}
+
+impl<I> MaxNumDigits for Integer<I>
+where
+    I: Bounded + Zero + DivAssign + Ord + Copy,
+{
+    /// Returns the maximum number of digits a nonnegative representation of `I` can have depending
+    /// on `radix`.
+    fn max_num_digits(radix: Integer<I>) -> usize {
+        let mut max = I::max_value();
+        let mut d = 0;
+        while max > I::zero() {
+            d += 1;
+            max /= radix.0;
+        }
+        d
+    }
+
+    /// Returns the maximum number of digits a negative representation of `I` can have depending
+    /// on `radix`.
+    fn max_num_digits_negative(radix: Integer<I>) -> usize {
+        let mut min = I::min_value();
+        let mut d = 0;
+        while min < I::zero() {
+            d += 1;
+            min /= radix.0;
+        }
+        d
+    }
+}

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -228,7 +228,7 @@ fn ascii_to_hexdigit<I>(character: u8) -> Option<I>
 where
     I: Zero + One,
 {
-    match character {
+    match character.to_ascii_uppercase() {
         b'0' => Some(nth(0)),
         b'1' => Some(nth(1)),
         b'2' => Some(nth(2)),
@@ -239,12 +239,12 @@ where
         b'7' => Some(nth(7)),
         b'8' => Some(nth(8)),
         b'9' => Some(nth(9)),
-        b'a' | b'A' => Some(nth(10)),
-        b'b' | b'B' => Some(nth(11)),
-        b'c' | b'C' => Some(nth(12)),
-        b'd' | b'D' => Some(nth(13)),
-        b'e' | b'E' => Some(nth(14)),
-        b'f' | b'F' => Some(nth(15)),
+        b'A' => Some(nth(10)),
+        b'B' => Some(nth(11)),
+        b'C' => Some(nth(12)),
+        b'D' => Some(nth(13)),
+        b'E' => Some(nth(14)),
+        b'F' => Some(nth(15)),
         _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use num_traits::Signed;
 mod builtin;
 mod integer;
 
-pub use integer::{ascii_to_digit, Integer};
+pub use integer::Integer;
 
 /// Parses an integer from a slice.
 ///
@@ -326,6 +326,38 @@ impl Sign {
             Sign::Minus => -I::one(),
         }
     }
+}
+
+/// Construct an instance of a numerical type using the byte representation of a radix 10 digit,
+/// e.g. b'7' -> 7.
+pub trait FromDigit: Sized {
+    /// Convert ASCII digit (e.g. b'7) into numeric representation (`7`). `None` if the character
+    /// given does not represent a digit in ASCII.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use atoi::FromDigit;
+    /// assert_eq!(Some(5), u32::from_digit(b'5'));
+    /// assert_eq!(None, u32::from_digit(b'x'));
+    /// ```
+    fn from_digit(digit: u8) -> Option<Self>;
+}
+
+/// Converts an ascii character to digit
+///
+/// # Example
+///
+/// ```
+/// use atoi::ascii_to_digit;
+/// assert_eq!(Some(5), ascii_to_digit(b'5'));
+/// assert_eq!(None, ascii_to_digit::<u32>(b'x'));
+/// ```
+pub fn ascii_to_digit<I>(digit: u8) -> Option<I>
+where
+    I: FromDigit,
+{
+    I::from_digit(digit)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,10 @@ pub trait FromDigit: Sized {
     fn from_digit(digit: u8) -> Option<Self>;
 }
 
+trait FromHexDigit: Sized {
+    fn from_hex_digit(digit: u8) -> Option<Self>;
+}
+
 /// Converts an ascii character to digit
 ///
 /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,14 +21,12 @@
 //! ```
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use core::{
-    cmp::{max, min},
-    ops::{AddAssign, DivAssign, MulAssign, SubAssign},
-};
-use num_traits::{
-    Bounded, CheckedSub, One, Signed, Zero,
-    ops::checked::{CheckedAdd, CheckedMul},
-};
+use num_traits::Signed;
+
+mod builtin;
+mod integer;
+
+pub use integer::{ascii_to_digit, Integer};
 
 /// Parses an integer from a slice.
 ///
@@ -105,7 +103,7 @@ pub trait FromRadix10: Sized {
 
 /// Types implementing this trait can be parsed from a positional numeral system with radix 10.
 /// Acts much like `FromRadix10`, but performs additional checks for overflows.
-pub trait FromRadix10Checked: FromRadix10 {
+pub trait FromRadix10Checked: Sized {
     /// Parses an integer from a slice.
     ///
     /// # Example
@@ -170,8 +168,8 @@ pub trait FromRadix16: Sized {
 }
 
 /// Types implementing this trait can be parsed from a positional numeral system with radix 16.
-/// Acts much like `FromRadix16`, but performs additional checks for overflows.
-pub trait FromRadix16Checked: FromRadix16 {
+/// Acts much like [`FromRadix16`], but performs additional checks for overflows.
+pub trait FromRadix16Checked: Sized {
     /// Parses an integer from a slice.
     ///
     /// # Example
@@ -292,305 +290,6 @@ pub trait MaxNumDigits {
     fn max_num_digits_negative(radix: Self) -> usize;
 }
 
-impl<I> MaxNumDigits for I
-where
-    I: Bounded + Zero + DivAssign + Ord + Copy,
-{
-    /// Returns the maximum number of digits a nonnegative representation of `I` can have depending
-    /// on `radix`.
-    fn max_num_digits(radix: I) -> usize {
-        let mut max = I::max_value();
-        let mut d = 0;
-        while max > I::zero() {
-            d += 1;
-            max /= radix;
-        }
-        d
-    }
-
-    /// Returns the maximum number of digits a negative representation of `I` can have depending
-    /// on `radix`.
-    fn max_num_digits_negative(radix: I) -> usize {
-        let mut min = I::min_value();
-        let mut d = 0;
-        while min < I::zero() {
-            d += 1;
-            min /= radix;
-        }
-        d
-    }
-}
-
-/// Converts an ascii character to digit
-///
-/// # Example
-///
-/// ```
-/// use atoi::ascii_to_digit;
-/// assert_eq!(Some(5), ascii_to_digit(b'5'));
-/// assert_eq!(None, ascii_to_digit::<u32>(b'x'));
-/// ```
-pub fn ascii_to_digit<I>(character: u8) -> Option<I>
-where
-    I: Zero + One,
-{
-    match character {
-        b'0' => Some(nth(0)),
-        b'1' => Some(nth(1)),
-        b'2' => Some(nth(2)),
-        b'3' => Some(nth(3)),
-        b'4' => Some(nth(4)),
-        b'5' => Some(nth(5)),
-        b'6' => Some(nth(6)),
-        b'7' => Some(nth(7)),
-        b'8' => Some(nth(8)),
-        b'9' => Some(nth(9)),
-        _ => None,
-    }
-}
-
-impl<I> FromRadix10 for I
-where
-    I: Zero + One + AddAssign + MulAssign,
-{
-    fn from_radix_10(text: &[u8]) -> (Self, usize) {
-        let mut index = 0;
-        let mut number = I::zero();
-        while index != text.len() {
-            if let Some(digit) = ascii_to_digit(text[index]) {
-                number *= nth(10);
-                number += digit;
-                index += 1;
-            } else {
-                break;
-            }
-        }
-        (number, index)
-    }
-}
-
-impl<I> FromRadix10Signed for I
-where
-    I: Zero + One + AddAssign + SubAssign + MulAssign,
-{
-    fn from_radix_10_signed(text: &[u8]) -> (Self, usize) {
-        let mut index;
-        let mut number = I::zero();
-
-        let (sign, offset) = text
-            .first()
-            .and_then(|&byte| Sign::try_from(byte))
-            .map(|sign| (sign, 1))
-            .unwrap_or((Sign::Plus, 0));
-
-        index = offset;
-
-        // Having two dedicated loops for both the negative and the nonnegative case is rather
-        // verbose, yet performed up to 40% better then a more terse single loop with
-        // `number += digit * signum`.
-
-        match sign {
-            Sign::Plus => {
-                while index != text.len() {
-                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
-                        number *= nth(10);
-                        number += digit;
-                        index += 1;
-                    } else {
-                        break;
-                    }
-                }
-            }
-            Sign::Minus => {
-                while index != text.len() {
-                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
-                        number *= nth(10);
-                        number -= digit;
-                        index += 1;
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-
-        (number, index)
-    }
-}
-
-impl<I> FromRadix10SignedChecked for I
-where
-    I: Zero
-        + One
-        + AddAssign
-        + MulAssign
-        + SubAssign
-        + CheckedAdd
-        + CheckedSub
-        + CheckedMul
-        + MaxNumDigits,
-{
-    fn from_radix_10_signed_checked(text: &[u8]) -> (Option<Self>, usize) {
-        let mut index;
-        let mut number = I::zero();
-
-        let (sign, offset) = text
-            .first()
-            .and_then(|&byte| Sign::try_from(byte))
-            .map(|sign| (sign, 1))
-            .unwrap_or((Sign::Plus, 0));
-
-        index = offset;
-
-        // Having two dedicated loops for both the negative and the nonnegative case is rather
-        // verbose, yet performed up to 40% better then a more terse single loop with
-        // `number += digit * signum`.
-
-        match sign {
-            Sign::Plus => {
-                let max_safe_digits = max(1, I::max_num_digits(nth(10))) - 1;
-                let max_safe_index = min(text.len(), max_safe_digits + offset);
-                while index != max_safe_index {
-                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
-                        number *= nth(10);
-                        number += digit;
-                        index += 1;
-                    } else {
-                        break;
-                    }
-                }
-                // We parsed the digits, which do not need checking now lets see the next one:
-                let mut number = Some(number);
-                while index != text.len() {
-                    if let Some(digit) = ascii_to_digit(text[index]) {
-                        number = number.and_then(|n| n.checked_mul(&nth(10)));
-                        number = number.and_then(|n| n.checked_add(&digit));
-                        index += 1;
-                    } else {
-                        break;
-                    }
-                }
-                (number, index)
-            }
-            Sign::Minus => {
-                let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
-                let max_safe_index = min(text.len(), max_safe_digits + offset);
-                while index != max_safe_index {
-                    if let Some(digit) = ascii_to_digit::<I>(text[index]) {
-                        number *= nth(10);
-                        number -= digit;
-                        index += 1;
-                    } else {
-                        break;
-                    }
-                }
-                // We parsed the digits, which do not need checking now lets see the next one:
-                let mut number = Some(number);
-                while index != text.len() {
-                    if let Some(digit) = ascii_to_digit(text[index]) {
-                        number = number.and_then(|n| n.checked_mul(&nth(10)));
-                        number = number.and_then(|n| n.checked_sub(&digit));
-                        index += 1;
-                    } else {
-                        break;
-                    }
-                }
-                (number, index)
-            }
-        }
-    }
-}
-
-impl<I> FromRadix10Checked for I
-where
-    I: Zero + One + FromRadix10 + CheckedMul + CheckedAdd + MaxNumDigits,
-{
-    fn from_radix_10_checked(text: &[u8]) -> (Option<I>, usize) {
-        let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
-        let (number, mut index) = I::from_radix_10(&text[..min(text.len(), max_safe_digits)]);
-        let mut number = Some(number);
-        // We parsed the digits, which do not need checking now lets see the next one:
-        while index != text.len() {
-            if let Some(digit) = ascii_to_digit(text[index]) {
-                number = number.and_then(|n| n.checked_mul(&nth(10)));
-                number = number.and_then(|n| n.checked_add(&digit));
-                index += 1;
-            } else {
-                break;
-            }
-        }
-        (number, index)
-    }
-}
-
-/// Converts an ascii character to digit
-fn ascii_to_hexdigit<I>(character: u8) -> Option<I>
-where
-    I: Zero + One,
-{
-    match character {
-        b'0' => Some(nth(0)),
-        b'1' => Some(nth(1)),
-        b'2' => Some(nth(2)),
-        b'3' => Some(nth(3)),
-        b'4' => Some(nth(4)),
-        b'5' => Some(nth(5)),
-        b'6' => Some(nth(6)),
-        b'7' => Some(nth(7)),
-        b'8' => Some(nth(8)),
-        b'9' => Some(nth(9)),
-        b'a' | b'A' => Some(nth(10)),
-        b'b' | b'B' => Some(nth(11)),
-        b'c' | b'C' => Some(nth(12)),
-        b'd' | b'D' => Some(nth(13)),
-        b'e' | b'E' => Some(nth(14)),
-        b'f' | b'F' => Some(nth(15)),
-        _ => None,
-    }
-}
-
-impl<I> FromRadix16 for I
-where
-    I: Zero + One + AddAssign + MulAssign,
-{
-    fn from_radix_16(text: &[u8]) -> (Self, usize) {
-        let mut index = 0;
-        let mut number = I::zero();
-        while index != text.len() {
-            if let Some(digit) = ascii_to_hexdigit(text[index]) {
-                number *= nth(16);
-                number += digit;
-                index += 1;
-            } else {
-                break;
-            }
-        }
-        (number, index)
-    }
-}
-
-impl<I> FromRadix16Checked for I
-where
-    I: Zero + One + FromRadix16 + CheckedMul + CheckedAdd + MaxNumDigits,
-{
-    fn from_radix_16_checked(text: &[u8]) -> (Option<I>, usize) {
-        let max_safe_digits = max(1, I::max_num_digits_negative(nth(10))) - 1;
-        let (number, mut index) = I::from_radix_16(&text[..min(text.len(), max_safe_digits)]);
-        let mut number = Some(number);
-        // We parsed the digits, which do not need checking now lets see the next one:
-        while index != text.len() {
-            if let Some(digit) = ascii_to_hexdigit(text[index]) {
-                number = number.and_then(|n| n.checked_mul(&nth(16)));
-                number = number.and_then(|n| n.checked_add(&digit));
-                index += 1;
-            } else {
-                break;
-            }
-        }
-        (number, index)
-    }
-}
-
 /// Representation of a numerical sign
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Sign {
@@ -627,19 +326,6 @@ impl Sign {
             Sign::Minus => -I::one(),
         }
     }
-}
-
-// At least for primitive types this function does not incur runtime costs, since it is only called
-// with constants
-fn nth<I>(n: u8) -> I
-where
-    I: Zero + One,
-{
-    let mut i = I::zero();
-    for _ in 0..n {
-        i = i + I::one();
-    }
-    i
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub use integer::Integer;
 /// # Return
 ///
 /// Returns a a number if the slice started with a number, otherwise `None` is returned.
+#[inline]
 pub fn atoi<I>(text: &[u8]) -> Option<I>
 where
     I: FromRadix10SignedChecked,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,4 +409,11 @@ mod test {
         assert_eq!((Some(25), 2), u8::from_radix_16_checked(b"19"));
         assert_eq!((Some(25), 2), u8::from_radix_16_checked(b"19!Blub"));
     }
+
+    #[test]
+    fn ascii_to_digit_wrapper() {
+        assert_eq!(Some(0), ascii_to_digit(b'0'));
+        assert_eq!(Some(9), ascii_to_digit(b'9'));
+        assert_eq!(None, ascii_to_digit::<u8>(b'!'));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,9 @@ mod test {
     #[test]
     fn checked_parsing_radix_16() {
         assert_eq!((Some(255), 2), u8::from_radix_16_checked(b"FF"));
+        assert_eq!((Some(255), 2), u8::from_radix_16_checked(b"ff"));
+        assert_eq!((Some(170), 2), u8::from_radix_16_checked(b"AA"));
+        assert_eq!((Some(170), 2), u8::from_radix_16_checked(b"aa"));
         assert_eq!((None, 3), u8::from_radix_16_checked(b"100"));
         assert_eq!((None, 4), u8::from_radix_16_checked(b"1000"));
         assert_eq!((Some(25), 2), u8::from_radix_16_checked(b"19"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,22 +371,22 @@ mod test {
 
     #[test]
     fn max_digits() {
-        assert_eq!(10, i32::max_num_digits(10));
-        assert_eq!(10, u32::max_num_digits(10));
-        assert_eq!(19, i64::max_num_digits(10));
-        assert_eq!(20, u64::max_num_digits(10));
-        assert_eq!(3, u8::max_num_digits(10));
-        assert_eq!(3, i8::max_num_digits(10));
+        assert_eq!(10, Integer::<i32>::max_num_digits(Integer(10)));
+        assert_eq!(10, Integer::<u32>::max_num_digits(Integer(10)));
+        assert_eq!(19, Integer::<i64>::max_num_digits(Integer(10)));
+        assert_eq!(20, Integer::<u64>::max_num_digits(Integer(10)));
+        assert_eq!(3, Integer::<u8>::max_num_digits(Integer(10)));
+        assert_eq!(3, Integer::<i8>::max_num_digits(Integer(10)));
     }
 
     #[test]
     fn max_digits_negative() {
-        assert_eq!(10, i32::max_num_digits_negative(10));
-        assert_eq!(0, u32::max_num_digits_negative(10));
-        assert_eq!(19, i64::max_num_digits_negative(10));
-        assert_eq!(0, u64::max_num_digits_negative(10));
-        assert_eq!(0, u8::max_num_digits_negative(10));
-        assert_eq!(3, i8::max_num_digits_negative(10));
+        assert_eq!(10, Integer::<i32>::max_num_digits_negative(Integer(10)));
+        assert_eq!(0, Integer::<u32>::max_num_digits_negative(Integer(10)));
+        assert_eq!(19, Integer::<i64>::max_num_digits_negative(Integer(10)));
+        assert_eq!(0, Integer::<u64>::max_num_digits_negative(Integer(10)));
+        assert_eq!(0, Integer::<u8>::max_num_digits_negative(Integer(10)));
+        assert_eq!(3, Integer::<i8>::max_num_digits_negative(Integer(10)));
     }
 
     #[test]


### PR DESCRIPTION
- **refactor: integer**
- **feat!: introduce from digit**
- **feat!: introduce FromHexDigit**
- **refactor: copy more implementations from integer to builtin**
- **move signed checked implementations to builtin from integer**
- **perf: Speed up hexdigit parsing by using masks to unify ascii cases**
- **refactor: use FromDigit internally instead of ascii_to_digit**
- **refactor!: builtin types implemented indpendent from Integer**
- **perf: Inline from_radix_* functions for builtin types**
- **perf: inline atoi**
